### PR TITLE
add callsite dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1044,8 +1044,7 @@
     "callsite": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/callsite/-/callsite-1.0.0.tgz",
-      "integrity": "sha1-KAOY5dZkvXQDi28JBRU+borxvCA=",
-      "dev": true
+      "integrity": "sha1-KAOY5dZkvXQDi28JBRU+borxvCA="
     },
     "callsites": {
       "version": "3.1.0",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   "author": "Mihkel Eidast <mihkel@play.ee> (https://play.ee)",
   "license": "MIT",
   "dependencies": {
+    "callsite": "^1.0.0",
     "lodash": "^4.17.20",
     "react-jsx-parser": "^1.27.0",
     "ts-node": "^9.0.0",


### PR DESCRIPTION
decache.js imports the `callsite` module, but it's not listed under direct dependencies.

It's installed as a transitive dependency of some older versions of Fractal (which is why this hasn't been a problem in the past), but not with the newest.